### PR TITLE
Adds synonym searching support for the front end

### DIFF
--- a/src/css/customTextInput.scss
+++ b/src/css/customTextInput.scss
@@ -68,14 +68,21 @@ input[type=text] {
         & > li {
             padding: 7px 5px;
             word-break: break-all;
+            overflow: hidden;
             cursor: pointer;
+            text-overflow: ellipsis;
             &.selected {
                 background-color: $lightGreen;
+            }
+
+            & .badge {
+                margin-right: 0.25em;
+                max-width: 100%;
             }
         }
     }
 
-    & span {
+    & > span {
         text-align: center;
         width: 100%;
         margin: 0 auto;

--- a/src/js/domain/keyword/selectors.js
+++ b/src/js/domain/keyword/selectors.js
@@ -9,9 +9,10 @@ const keywordSearchResults = state => state.domain[name].keywordSearchResults;
 export const keywordSearchIndexSelector = createSelector(
     keywordSearchResults,
     results => results.reduce((acc, cur) => {
-        acc[cur.id] = {
+        acc[cur.id + cur.synonym] = {
             name: cur.name,
             external_id: cur.external_id,
+            synonym: cur.synonym,
             evidence_code: cur.evidence_code
         };
         return acc;
@@ -20,5 +21,5 @@ export const keywordSearchIndexSelector = createSelector(
 
 export const keywordSearchOrderSelector = createSelector(
     keywordSearchResults,
-    results => results.map(v => v.id)
+    results => results.map(v => v.id + v.synonym)
 );

--- a/src/js/lib/components/smartTextInput/subcomponents/suggestionList.jsx
+++ b/src/js/lib/components/smartTextInput/subcomponents/suggestionList.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Badge } from 'reactstrap';
 
 class SuggestionList extends React.Component {
     constructor(props) {
@@ -20,11 +21,21 @@ class SuggestionList extends React.Component {
 
     generateListElement(suggestionId, index) {
         let suggestion = this.props.suggestionIndex[suggestionId];
-        let suggestionText =
-            typeof suggestion == 'object' ?
-            (suggestion.external_id ? suggestion.external_id + ": " : "")
-                + suggestion.name
-            : suggestion;
+        let suggestionText;
+        if (typeof suggestion == 'object') {
+            suggestionText = (<span>
+                    <Badge color="success">
+                        {suggestion.external_id}
+                    </Badge>
+                    {suggestion.name}
+                    {suggestion.synonym ? 
+                    <Badge color="warning">
+                        Synonym matched: {suggestion.synonym}
+                    </Badge>: null}
+                    </span>);
+        } else {
+            suggestionText = suggestion;
+        }
 
         return (
             <li


### PR DESCRIPTION
This fixes tair/toastdos-back#205 from the front-end.
This also includes new styles for the keyword list items:
![image](https://user-images.githubusercontent.com/1115017/35712594-c16457d8-0790-11e8-91bb-211445e6608b.png)
