### PR TITLE
Fixing reactstrap until we can upgrade bootstrap to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "react-redux": "^4.4.5",
     "react-router": "^2.8.1",
     "react-router-redux": "^4.0.6",
-    "reactstrap": "^5.0.0-alpha.3",
+    "reactstrap": "5.0.0-alpha.3",
     "redux": "^3.6.0",
     "redux-thunk": "^2.1.0",
     "reselect": "^2.5.4",


### PR DESCRIPTION
I've made an issue to track this: tair/toastdos-back#250