### PR TITLE
Adds exports view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,6 +184,8 @@ GitHub.sublime-settings
 
 bin/
 
+resources/orcid_app_info.json
+
 .vscode
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -184,8 +184,6 @@ GitHub.sublime-settings
 
 bin/
 
-resources/orcid_app_info.json
-
 .vscode
 
 

--- a/scripts/generateOrcidFile.js
+++ b/scripts/generateOrcidFile.js
@@ -1,8 +1,13 @@
 #!/usr/bin/env node
 "use strict";
 
-const DESTINATION_DIR = "./resources";
-const FILENAME = "orcid_app_info.json";
+if(!process.env.RESOURCEROOT) {
+	console.error('No environment variable RESOURCEROOT found.');
+	process.exit(1);
+}
+
+const DESTINATION_DIR = process.env.RESOURCEROOT;
+const FILENAME = "orcid_public_info.json";
 
 const jsonfile  = require('jsonfile');
 const fs        = require('fs');

--- a/src/js/app.jsx
+++ b/src/js/app.jsx
@@ -12,6 +12,7 @@ import submissionModule from 'modules/submission';
 import navigationModule from 'modules/navigation';
 import curationDetailModule from 'modules/curationDetail';
 import curationOverviewModule from 'modules/curationOverview';
+import exportsView from 'modules/exportsView';
 
 import { isAuthenticated, redirectIfLoggedIn } from 'lib/routeChecks';
 import DefaultLoadingAnimation from 'lib/components/loadingAnimations/defaultLoadingAnimation';
@@ -68,6 +69,10 @@ class App extends React.Component {
                         path="curation"
                         component={curationOverviewModule.components.CurationOverviewView}
                         onEnter={isAuthenticated}
+                    />
+                    <Route
+                        path="exports"
+                        component={exportsView.components.ExportsView}
                     />
                 </Route>
             </Router>

--- a/src/js/lib/api/real.js
+++ b/src/js/lib/api/real.js
@@ -251,3 +251,20 @@ export function getSubmission(submissionId, jwt, callback) {
         return callback(null, body);
     });
 }
+
+export function listExports(callback) {
+    return request({
+        method: 'GET',
+        timeout: 15000,
+        url: `${BASE_URL}/api/exports/`,
+        json: true,
+    }, (err, res, body) => {
+        if(err) {
+            return callback(err);
+        }
+        if(res.status < 200 || res.status >= 300) {
+            return callback(err);
+        }
+        return callback(null, body);
+    });
+}

--- a/src/js/modules/connectedComponents/exportsView.js
+++ b/src/js/modules/connectedComponents/exportsView.js
@@ -1,0 +1,24 @@
+"use strict";
+
+import { connect } from 'react-redux';
+import { createStructuredSelector } from 'reselect';
+import ExportsView from 'ui/exportsView';
+import {
+   exportsList,
+   loadingExportsList
+  } from 'modules/exportsView/selectors';
+import {
+    requestExportsList
+} from 'modules/exportsView/actions';
+
+const ConnectedExportsView = connect(
+    createStructuredSelector({
+        exportsList,
+        loadingExportsList
+    }),
+    dispatch => ({
+        loadExports: () => dispatch(requestExportsList()),
+    })
+)(ExportsView);
+
+export default ConnectedExportsView;

--- a/src/js/modules/exportsView/actionTypes.js
+++ b/src/js/modules/exportsView/actionTypes.js
@@ -1,0 +1,3 @@
+export const REQUEST_EXPORTS_LIST = "curation/REQUEST_EXPORTS_LIST";
+export const FAIL_EXPORTS_LIST = "curation/FAIL_EXPORTS_LIST";
+export const SUCCESS_EXPORTS_LIST = "curation/SUCCESS_EXPORTS_LIST";

--- a/src/js/modules/exportsView/actions.js
+++ b/src/js/modules/exportsView/actions.js
@@ -1,0 +1,34 @@
+"use strict";
+
+import * as api from 'lib/api';
+import * as actions from './actionTypes';
+
+function failExportsList(error) {
+    return {
+        type: actions.FAIL_EXPORTS_LIST,
+        error,
+    };
+}
+
+function successExportsList(data) {
+    return {
+        type: actions.SUCCESS_EXPORTS_LIST,
+        data,
+    };
+}
+
+export function requestExportsList() {
+    return (dispatch, getState) => {
+
+        dispatch({
+            type: actions.REQUEST_EXPORTS_LIST,
+        });
+
+        return api.listExports((err, data) => {
+            if (err) {
+                return dispatch(failExportsList(err));
+            }
+            return dispatch(successExportsList(data));
+        });
+    };
+}

--- a/src/js/modules/exportsView/constants.js
+++ b/src/js/modules/exportsView/constants.js
@@ -1,0 +1,3 @@
+"use strict";
+
+export const name = "exportsView";

--- a/src/js/modules/exportsView/index.js
+++ b/src/js/modules/exportsView/index.js
@@ -1,0 +1,13 @@
+"use strict";
+
+import reducer from './reducer';
+import * as constants from './constants';
+import ExportsView from 'modules/connectedComponents/exportsView';
+
+export default {
+    constants,
+    reducer,
+    components: {
+        ExportsView,
+    },
+};

--- a/src/js/modules/exportsView/reducer.js
+++ b/src/js/modules/exportsView/reducer.js
@@ -1,0 +1,32 @@
+"use strict";
+
+import * as actions from './actionTypes';
+
+const defaultState = {
+    loadingExportsList: false,
+    exportsListLoadError: null,
+    exportsList: []
+};
+
+
+export default function (state = defaultState, action) {
+    switch (action.type) {
+    case actions.REQUEST_EXPORTS_LIST:
+        return Object.assign({}, state, {
+            loadingExportsList: true,
+            exportsListLoadError: null,
+        });
+    case actions.SUCCESS_EXPORTS_LIST:
+        return Object.assign({}, state, {
+            loadingExportsList: false,
+            exportsList: action.data,
+        });
+    case actions.FAIL_EXPORTS_LIST:
+        return Object.assign({}, state, {
+            loadingExportsList: false,
+            exportsListLoadError: action.error,
+        });
+    default:
+        return state;
+    }
+}

--- a/src/js/modules/exportsView/selectors.js
+++ b/src/js/modules/exportsView/selectors.js
@@ -1,0 +1,6 @@
+"use strict";
+
+import { name } from './constants';
+
+export const exportsList = state => state[name].exportsList;
+export const loadingExportsList = state => state[name].loadingExportsList;

--- a/src/js/modules/navigation/components/navigationFrame/navigationFrame.jsx
+++ b/src/js/modules/navigation/components/navigationFrame/navigationFrame.jsx
@@ -20,6 +20,11 @@ class NavigationFrame extends React.Component {
                 to: '/curation',
                 name: 'Curation',
                 show: () => this.props.userRoles.includes('Curator')
+            },
+            {
+                to: '/exports',
+                name: 'Exports',
+                show: () => true
             }
         ];
 

--- a/src/js/modules/navigation/components/navigationFrame/subComponents/navigationBar.jsx
+++ b/src/js/modules/navigation/components/navigationFrame/subComponents/navigationBar.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { Collapse, Navbar, NavbarToggler, NavbarBrand, Nav, NavItem, NavLink,
     Dropdown, DropdownMenu, DropdownItem, DropdownToggle } from 'reactstrap';
 import  {Link} from 'react-router';
-import orcidInfo from 'resources/orcid_app_info';
+import orcidInfo from 'resources/orcid_public_info';
 import userInfoModule from 'modules/userInfo';
 import goatLogo from 'img/goat.svg'
 

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -15,6 +15,7 @@ import domain from 'domain';
 import submission from 'modules/submission';
 import curationDetail from 'modules/curationDetail';
 import curationOverview from 'modules/curationOverview';
+import exportsView from 'modules/exportsView';
 
 let reducer = combineReducers({
     [home.constants.name]: home.reducer,
@@ -25,6 +26,7 @@ let reducer = combineReducers({
     [submission.constants.name]: submission.reducer,
     [curationDetail.constants.name]: curationDetail.reducer,
     [curationOverview.constants.name]: curationOverview.reducer,
+    [exportsView.constants.name]: exportsView.reducer,
     routing: routerReducer
 });
 

--- a/src/js/ui/exportsView.jsx
+++ b/src/js/ui/exportsView.jsx
@@ -1,0 +1,78 @@
+"use strict";
+
+import React from 'react';
+import {Container, Row, Col, Card, CardHeader, CardBody, ListGroup, ListGroupItem} from 'reactstrap';
+import config from '../../../config';
+
+class ExportsView extends React.Component {
+    constructor(props) {
+        super(props);
+        
+        this.state = {
+
+        };
+        this.renderExportList = this.renderExportList.bind(this);
+    }
+
+    componentDidMount() {
+        this.props.loadExports();
+    }
+
+    renderExportItem(item, i) {
+        return (
+            <ListGroupItem tag="a" target="_blank" href={`${config.apiBase}/api/exports/files/${item}`} key={i} download>
+                {item}
+            </ListGroupItem>
+        );
+    }
+
+    renderExportList() {
+        return (
+            <ListGroup className="list-group-flush">
+                {this.props.exportsList.map(this.renderExportItem)}
+            </ListGroup>
+        );
+    }
+
+    renderLoading() {
+        return (
+            <div className="text-center py-3">
+                <span className="fa fa-spin fa-refresh fa-3x" />
+            </div>
+        );
+    }
+
+    render() {
+        return (
+            <Container fluid className="mt-3">
+                <Row className="justify-content-md-center">
+                    <Col md="10">
+                        <Card className="submission-view">
+                            <CardHeader>
+                                <span className="fa fa-file" /> Exports
+                            </CardHeader>
+                            <CardBody className="p-0">
+                                {this.props.loadingExportsList ? this.renderLoading(): 
+                                    this.renderExportList()}
+                            </CardBody>
+                        </Card>
+                    </Col>
+                </Row>
+            </Container>
+        );
+    }
+}
+
+ExportsView.propTypes = {
+    loadExports: React.PropTypes.func,
+    exportsList: React.PropTypes.arrayOf(React.PropTypes.string),
+    loadingExportsList: React.PropTypes.bool,
+};
+
+ExportsView.defaultProps = {
+    loadExports: () => {},
+    exportsList: [],
+    loadingExportsList: true
+};
+
+export default ExportsView;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,10 @@ const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 
+if(!process.env.RESOURCEROOT) {
+	console.error('No environment variable RESOURCEROOT found.');
+	process.exit(1);
+}
 
 module.exports = {
     entry: './src/index.js',
@@ -69,7 +73,7 @@ module.exports = {
             lib: path.resolve(__dirname, './src/js/lib'),
             modules: path.resolve(__dirname, './src/js/modules'),
             ui: path.resolve(__dirname, './src/js/ui'),
-            resources: path.resolve(__dirname, "./resources"),
+            resources: path.resolve(process.env.RESOURCEROOT),
         },
     },
 };

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -81,7 +81,7 @@ module.exports = {
             lib: path.resolve(__dirname, './src/js/lib'),
             modules: path.resolve(__dirname, './src/js/modules'),
             ui: path.resolve(__dirname, './src/js/ui'),
-            resources: path.resolve(__dirname, "./resources"),
+            resources: path.resolve(process.env.RESOURCEROOT),
         },
     },
 };

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -4,6 +4,11 @@ const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 
+if(!process.env.RESOURCEROOT) {
+	console.error('No environment variable RESOURCEROOT found.');
+	process.exit(1);
+}
+
 
 module.exports = {
     entry: './src/index.js',


### PR DESCRIPTION
This adds the export view to the frontend. It relies on the new shared resources folder from 
tair/toastdos-back#254

The following manual migration is required from the project directory (after doing the backend):
```
cp ./resources/orcid_app_info.json ../resources/orcid_public_info.json
rm -rf resources
```
Note the name change of the file. Also ensure the `RESOURCEROOT` environment variable is set.

Here's what the view looks like:
![image](https://user-images.githubusercontent.com/1115017/36326430-07f56586-1329-11e8-9bca-8fafd01199bc.png)
