### PR TITLE
Show eco keywords by default and restrict evidence codes

### DIFF
--- a/src/js/domain/keyword/actions.js
+++ b/src/js/domain/keyword/actions.js
@@ -18,7 +18,7 @@ function keywordSearchFail(error) {
     };
 }
 
-export function attemptKeywordSearch(searchTerm, keywordScope) {
+export function attemptKeywordSearch(searchTerm, keywordScope, annotationType) {
     return (dispatch, getState) => {
 
         const currState = getState();
@@ -28,7 +28,7 @@ export function attemptKeywordSearch(searchTerm, keywordScope) {
         });
 
         const token = AuthModule.selectors.rawJwtSelector(currState);
-        searchKeywords(searchTerm, keywordScope, token, (err, data) => {
+        searchKeywords(searchTerm, keywordScope, annotationType, token, (err, data) => {
             if(err) {
                 return dispatch(keywordSearchFail(err));
             }

--- a/src/js/lib/api/real.js
+++ b/src/js/lib/api/real.js
@@ -181,14 +181,15 @@ export function submitSubmission(submissionData, jwt, callback) {
     });
 }
 
-export function searchKeywords(searchTerm, keywordScope, jwt, callback) {
+export function searchKeywords(searchTerm, keywordScope, annotationType, jwt, callback) {
     return request({
         method: 'GET',
         timeout: 15000,
         url: `${BASE_URL}/api/keyword/search`,
         qs: {
             substring: searchTerm,
-            keyword_scope: keywordScope
+            keyword_scope: keywordScope,
+            annotation_type: annotationType
         },
         json: true,
         headers: {

--- a/src/js/modules/connectedComponents/keywordTextInput.js
+++ b/src/js/modules/connectedComponents/keywordTextInput.js
@@ -20,7 +20,7 @@ const ConnectedKeywordTextInput = connect(
         fetchingSuggestions: fetchingSuggestionsSelector
     }),
     dispatch => ({
-        performSearch: (searchTerm, keywordScope) => dispatch(attemptKeywordSearch(searchTerm, keywordScope)),
+        performSearch: (searchTerm, keywordScope, annotationType) => dispatch(attemptKeywordSearch(searchTerm, keywordScope, annotationType)),
         clearSearchData: () => dispatch(clearKeywordSearch())
     })
 )(KeywordTextInput);

--- a/src/js/ui/annotation/geneGene.jsx
+++ b/src/js/ui/annotation/geneGene.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import GenePicker from 'modules/connectedComponents/gene/picker';
 import KeywordTextInput from 'modules/connectedComponents/keywordTextInput';
 import LabelInputRow from 'ui/labelInputRow';
+import { annotationTypes } from 'domain/annotation/constants';
 
 class GeneGeneAnnotation extends React.Component {
     constructor(props) {
@@ -50,6 +51,8 @@ class GeneGeneAnnotation extends React.Component {
                         placeholder="e.g. Enzyme Assay"
                         value={this.props.geneGeneAnnotation.methodName}
                         searchScope="eco"
+                        minSuggestLength={0}
+                        annotationType={annotationTypes.PROTEIN_INTERACTION}
                         required={true}
                     />
                 </LabelInputRow>

--- a/src/js/ui/annotation/geneTerm.jsx
+++ b/src/js/ui/annotation/geneTerm.jsx
@@ -114,6 +114,8 @@ class GeneTermAnnotation extends React.Component {
                         placeholder="e.g. Enzyme Assay"
                         value={this.props.geneTermAnnotation.methodName}
                         searchScope="eco"
+                        minSuggestLength={0}
+                        annotationType={this.props.geneTermAnnotation.annotationType}
                         required={true}
                     />
                 </LabelInputRow>

--- a/src/js/ui/keywordTextInput.jsx
+++ b/src/js/ui/keywordTextInput.jsx
@@ -14,8 +14,8 @@ class KeywordTextInput extends React.Component {
 
     handleInputChange(value) {
         this.props.onChange(value);
-        if(value.name.length >= 3) {
-            this.props.performSearch(value.name, this.props.searchScope);
+        if (value.name.length >= this.props.minSuggestLength) {
+            this.props.performSearch(value.name, this.props.searchScope, this.props.annotationType);
         }
     }
 
@@ -24,8 +24,8 @@ class KeywordTextInput extends React.Component {
     }
 
     handleFocus() {
-        if(this.props.value.length >= 3) {
-            this.props.performSearch(this.props.value, this.props.searchScope);
+        if (this.props.value.length >= this.props.minSuggestLength) {
+            this.props.performSearch(this.props.value, this.props.searchScope, this.props.annotationType);
         }
     }
 
@@ -35,7 +35,7 @@ class KeywordTextInput extends React.Component {
                 onChange={this.handleInputChange}
                 onSelect={this.props.onSelect}
                 value={this.props.value}
-                minSuggestLength={3}
+                minSuggestLength={this.props.minSuggestLength}
                 placeholder={this.props.placeholder}
                 suggestionIndex={this.props.suggestionIndex}
                 suggestionOrder={this.props.suggestionOrder}
@@ -53,6 +53,8 @@ KeywordTextInput.propTypes = {
     onSelect: React.PropTypes.func.isRequired,
     value: React.PropTypes.string.isRequired,
     searchScope: React.PropTypes.string.isRequired,
+    annotationType: React.PropTypes.string,
+    minSuggestLength: React.PropTypes.number,
 
     suggestionIndex: React.PropTypes.object,
     suggestionOrder: React.PropTypes.array,
@@ -60,6 +62,10 @@ KeywordTextInput.propTypes = {
     clearSearchData: React.PropTypes.func.isRequired,
     fetchingSuggestions: React.PropTypes.bool.isRequired,
     placeholder: React.PropTypes.string
+};
+
+KeywordTextInput.defaultProps = {
+    minSuggestLength: 3
 };
 
 export default KeywordTextInput;


### PR DESCRIPTION
For Method/"eco" keyword searching, show an alphabetical list of applicable terms even with 0 characters typed. Other keyword fields are unaffected.