### PR TITLE
Add compact annotation review UI

### DIFF
--- a/src/js/domain/annotation/constants.js
+++ b/src/js/domain/annotation/constants.js
@@ -28,27 +28,32 @@ export const annotationTypeData = {
     [annotationTypes.MOLECULAR_FUNCTION]: {
         name: "Molecular Function (GO Function)",
         format: annotationFormats.GENE_TERM,
-        keywordScope: "molecular_function"
+        keywordScope: "molecular_function",
+        descriptor: "functions in"
     },
     [annotationTypes.BIOLOGICAL_PROCESS]: {
         name: "Biological Process (GO Process)",
         format: annotationFormats.GENE_TERM,
-        keywordScope: "biological_process"
+        keywordScope: "biological_process",
+        descriptor: "involved in (biological process)"
     },
     [annotationTypes.SUBCELLULAR_LOCATION]: {
         name: "Subcellular Location (GO Component)",
         format: annotationFormats.GENE_TERM,
-        keywordScope: "cellular_component"
+        keywordScope: "cellular_component",
+        descriptor: "located in"
     },
     [annotationTypes.ANATOMICAL_LOCATION]: {
         name: "Anatomical Location (PO Anatomy)",
         format: annotationFormats.GENE_TERM,
-        keywordScope: "plant_anatomy"
+        keywordScope: "plant_anatomy",
+        descriptor: "anatomically located in"
     },
     [annotationTypes.TEMPORAL_EXPRESSION]: {
         name: "Temporal Expression (PO Dev. Stage)",
         format: annotationFormats.GENE_TERM,
-        keywordScope: "plant_structure_development_stage"
+        keywordScope: "plant_structure_development_stage",
+        descriptor: "expressed in"
     },
     [annotationTypes.PROTEIN_INTERACTION]: {
         name: "Protein Interaction",
@@ -58,4 +63,33 @@ export const annotationTypeData = {
         name: "Comment",
         format: annotationFormats.COMMENT
     }
+};
+
+export const goEvidenceCodeNameMap = {
+    "EXP": "inferred from experiment",
+    "IDA": "inferred from direct assay",
+    "IPI": "inferred from physical interaction",
+    "IMP": "inferred from mutant phenotype",
+    "IGI": "inferred from genetic interaction",
+    "IEP": "inferred from expression pattern",
+    "HTP": "inferred from high throughput experiment",
+    "HDA": "inferred from high throughput direct assay",
+    "HMP": "inferred from high throughput mutant phenotype",
+    "HGI": "inferred from high throughput genetic interaction",
+    "HEP": "inferred from high throughput expression pattern",
+    "ISS": "inferred from sequence or structural similarity",
+    "ISO": "inferred from sequence orthology",
+    "ISA": "inferred from sequence alignment",
+    "ISM": "inferred from sequence model",
+    "IGC": "inferred from genomic context",
+    "IBA": "inferred from biological aspect of ancestor",
+    "IBD": "inferred from biological aspect of descendant",
+    "IKR": "inferred from key residues",
+    "IRD": "inferred from rapid divergence",
+    "RCA": "inferred from reviewed computational analysis",
+    "TAS": "traceable author statement",
+    "NAS": "non-traceable author statement",
+    "IC": "inferred by curator",
+    "ND": "no biological data available",
+    "IEA": "inferred from electronic annotation",
 };

--- a/src/js/ui/annotation/commentReadOnly.jsx
+++ b/src/js/ui/annotation/commentReadOnly.jsx
@@ -11,6 +11,21 @@ class CommentAnnotationReadOnly extends React.Component {
     }
 
     render() {
+        return this.props.compact? this.renderCompact() : this.renderLarge();
+    }
+
+    renderCompact() {
+        return (
+            <div>
+                <GeneLocusName localId={this.props.commentAnnotation.geneLocalId} />&nbsp;
+                <em>has the following comment:</em>&nbsp;
+                {this.props.commentAnnotation.comment}.&nbsp;
+                <AnnotationStatusReadOnly annotationStatus={this.props.annotationStatus} />
+            </div>
+        );
+    }
+
+    renderLarge() {
         return (
             <Card className="mb-3">
                 <CardHeader>
@@ -38,6 +53,7 @@ CommentAnnotationReadOnly.propTypes = {
     commentAnnotation: React.PropTypes.object,
     annotationStatus: React.PropTypes.string,
     annotationTypeName: React.PropTypes.string,
+    compact: React.PropTypes.bool,
 };
 
 export default CommentAnnotationReadOnly;

--- a/src/js/ui/annotation/entryReadOnly.jsx
+++ b/src/js/ui/annotation/entryReadOnly.jsx
@@ -24,6 +24,7 @@ class AnnotationEntryReadOnly extends React.Component {
                     localId={this.props.annotation.annotationTypeLocalId}
                     annotationTypeName={annotationType.name}
                     annotationStatus={this.props.annotation.annotationStatus}
+                    compact={this.props.compact}
                 />
             );
         case annotationFormats.GENE_TERM:
@@ -32,6 +33,7 @@ class AnnotationEntryReadOnly extends React.Component {
                     localId={this.props.annotation.annotationTypeLocalId}
                     annotationTypeName={annotationType.name}
                     annotationStatus={this.props.annotation.annotationStatus}
+                    compact={this.props.compact}
                 />
             );
         case annotationFormats.GENE_GENE:
@@ -40,6 +42,7 @@ class AnnotationEntryReadOnly extends React.Component {
                     localId={this.props.annotation.annotationTypeLocalId}
                     annotationTypeName={annotationType.name}
                     annotationStatus={this.props.annotation.annotationStatus}
+                    compact={this.props.compact}
                 />
             );
         default:
@@ -58,10 +61,12 @@ AnnotationEntryReadOnly.propTypes = {
         annotationType: React.PropTypes.oneOf(Object.keys(annotationTypes)),
         annotationTypeLocalId: React.PropTypes.string,
     }).isRequired,
+    compact: React.PropTypes.bool,
 };
 
 AnnotationEntryReadOnly.defaultProps = {
     annotation: null,
+    compact: true,
 };
 
 

--- a/src/js/ui/annotation/geneGeneReadOnly.jsx
+++ b/src/js/ui/annotation/geneGeneReadOnly.jsx
@@ -12,6 +12,31 @@ class GeneGeneAnnotationReadOnly extends React.Component {
     }
 
     render() {
+        return this.props.compact? this.renderCompact() : this.renderLarge();
+    }
+
+    renderCompact() {
+        let locus1 = (
+            <GeneLocusName
+                localId={this.props.geneGeneAnnotation.gene1LocalId}
+            />
+        );
+
+        let locus2 = (
+            <GeneLocusName
+                localId={this.props.geneGeneAnnotation.gene2LocalId}
+            />
+        );
+        return (
+            <div>
+                {locus1} <em>interacts with</em> {locus2}, {this.props.geneGeneAnnotation.methodName}&nbsp;
+                <ExternalIdBadge externalId={this.props.geneGeneAnnotation.methodExternalId} />.&nbsp;
+                <AnnotationStatusReadOnly annotationStatus={this.props.annotationStatus} />
+            </div>
+        );
+    }
+
+    renderLarge() {
         let locus1 = (
             <GeneLocusName
                 localId={this.props.geneGeneAnnotation.gene1LocalId}
@@ -60,6 +85,7 @@ class GeneGeneAnnotationReadOnly extends React.Component {
 GeneGeneAnnotationReadOnly.propTypes = {
     geneGeneAnnotation: React.PropTypes.object,
     annotationTypeName: React.PropTypes.string,
+    compact: React.PropTypes.bool,
 };
 
 export default GeneGeneAnnotationReadOnly;

--- a/src/js/ui/annotation/geneTermReadOnly.jsx
+++ b/src/js/ui/annotation/geneTermReadOnly.jsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { ListGroup, Card, CardHeader, CardBody, Label, Row, Col } from 'reactstrap';
-import { annotationTypeData } from 'domain/annotation/constants';
+import { annotationTypeData, goEvidenceCodeNameMap } from 'domain/annotation/constants';
 import EvidenceWithReadOnly from 'modules/connectedComponents/evidenceWithReadOnly';
 import ExternalIdBadge from 'ui/externalIdBadge';
 import GeneLocusName from 'modules/connectedComponents/gene/locusName';
@@ -16,6 +16,63 @@ class GeneTermAnnotationReadOnly extends React.Component {
     }
 
     render() {
+        return this.props.compact? this.renderCompact() : this.renderLarge();
+    }
+
+    renderCompact() {
+        let typeData = annotationTypeData[this.geneTermAnnotation.annotationType];
+        let showEvidenceWith = this.geneTermAnnotation.methodEvidenceCode == 'IPI' ||
+            this.geneTermAnnotation.methodEvidenceCode == 'IGI';
+        let locusName = (
+            <GeneLocusName
+                localId={this.props.geneTermAnnotation.geneLocalId}
+            />
+        );
+
+        let evidenceCodeName = this.geneTermAnnotation.methodEvidenceCode ?
+            (
+                goEvidenceCodeNameMap[this.geneTermAnnotation.methodEvidenceCode] +
+                ' (' +
+                this.geneTermAnnotation.methodEvidenceCode +
+                '), '
+            ): '';
+
+        let typeName = <em>{typeData.descriptor}</em>;
+
+        let evidenceWithText = null;
+        if (showEvidenceWith) {
+            const EWjoin = " " + this.props.geneTermAnnotation.evidenceWithRelation.toLowerCase() + " ";
+            evidenceWithText = (
+                <span>
+                    &nbsp;with&nbsp;
+                    {this.geneTermAnnotation.evidenceWithOrder.map(
+                        evidenceWithLocalId =>
+                            <EvidenceWithReadOnly
+                                key={evidenceWithLocalId}
+                                localId={evidenceWithLocalId}
+                                isListGroupItem={false}
+                            />
+                    ).reduce((prev, curr) => [prev, EWjoin, curr])}
+                </span>
+            );
+        }
+
+        return (
+            <div>
+                {locusName}&nbsp;
+                {typeName}&nbsp;
+                {this.geneTermAnnotation.keywordName}&nbsp;
+                <ExternalIdBadge externalId={this.geneTermAnnotation.keywordExternalId} />,&nbsp;
+                {evidenceCodeName}
+                {this.geneTermAnnotation.methodName}&nbsp;
+                <ExternalIdBadge externalId={this.geneTermAnnotation.methodExternalId} />
+                {evidenceWithText}.&nbsp;
+                <AnnotationStatusReadOnly annotationStatus={this.props.annotationStatus} />
+            </div>
+        );
+    }
+
+    renderLarge() {
         let typeData = annotationTypeData[this.geneTermAnnotation.annotationType];
         let showEvidenceWith = this.geneTermAnnotation.methodEvidenceCode == 'IPI' ||
             this.geneTermAnnotation.methodEvidenceCode == 'IGI';
@@ -100,6 +157,7 @@ GeneTermAnnotationReadOnly.propTypes = {
     localId: React.PropTypes.string,
     needsEvidenceWith: React.PropTypes.bool,
     annotationTypeName: React.PropTypes.string,
+    compact: React.PropTypes.bool,
 };
 
 GeneTermAnnotationReadOnly.defaultProps = {

--- a/src/js/ui/annotation/listCurationReadOnly.jsx
+++ b/src/js/ui/annotation/listCurationReadOnly.jsx
@@ -16,7 +16,8 @@ class AnnotationCurationListReadOnly extends React.Component {
             annotation =>
                 <AnnotationEntryReadOnly
                     key={annotation.localId}
-                    annotation={annotation} />
+                    annotation={annotation}
+                    compact={this.props.compact} />
         );
     }
 

--- a/src/js/ui/annotation/listReadOnly.jsx
+++ b/src/js/ui/annotation/listReadOnly.jsx
@@ -16,7 +16,8 @@ class AnnotationListReadOnly extends React.Component {
             localId =>
                 <AnnotationEntryReadOnly
                     key={localId}
-                    localId={localId} />
+                    localId={localId}
+                    compact={this.props.compact} />
         );
     }
 
@@ -43,10 +44,12 @@ class AnnotationListReadOnly extends React.Component {
 
 AnnotationListReadOnly.propTypes = {
     annotationOrder: React.PropTypes.arrayOf(React.PropTypes.string),
+    compact: React.PropTypes.bool,
 };
 
 AnnotationListReadOnly.defaultProps = {
     annotationOrder: [],
+    compact: true,
 };
 
 export default AnnotationListReadOnly;

--- a/src/js/ui/annotation/statusReadOnly.jsx
+++ b/src/js/ui/annotation/statusReadOnly.jsx
@@ -12,19 +12,19 @@ class AnnotationStatusReadOnly extends React.Component {
         switch (status) {
         case annotationStatusFormats.ACCEPTED:
             return (
-                    <span>
+                    <span className="text-nowrap">
                         <span className="fa fa-fw fa-check" /> Accepted
                     </span>
             );
         case annotationStatusFormats.REJECTED:
             return (
-                    <span>
+                    <span className="text-nowrap">
                         <span className="fa fa-fw fa-trash" /> Rejected
                     </span>
             );
         case annotationStatusFormats.PENDING:
             return (
-                    <span>
+                    <span className="text-nowrap">
                         <span className="fa fa-fw fa-pencil-square-o" /> Pending
                     </span>
             );

--- a/src/js/ui/curation/viewReadOnly.jsx
+++ b/src/js/ui/curation/viewReadOnly.jsx
@@ -6,10 +6,23 @@ import 'css/submissionView.scss';
 import PublicationFieldReadOnly from 'modules/connectedComponents/publication/fieldReadOnly';
 import GeneListReadOnly from 'ui/gene/listReadOnly';
 import AnnotationListReadOnly from 'modules/connectedComponents/annotation/listCurationReadOnly';
+import { Dropdown, DropdownToggle, DropdownMenu, DropdownItem } from 'reactstrap';
 
 class CurationReadOnly extends React.Component {
     constructor(props) {
         super(props);
+
+        this.state ={
+            dropdownOpen: false,
+            compact: true
+        };
+        this.toggleViewMode = this.toggleViewMode.bind(this);
+    }
+
+    toggleViewMode() {
+        this.setState({
+            dropdownOpen: !this.state.dropdownOpen
+        });
     }
 
     render() {
@@ -34,10 +47,20 @@ class CurationReadOnly extends React.Component {
                     <Row className="mt-3">
                         <Col sm="3">
                             <h5>Annotations</h5>
+                            <Dropdown isOpen={this.state.dropdownOpen} toggle={this.toggleViewMode}>
+                                <DropdownToggle caret color="success">
+                                    View Mode
+                                </DropdownToggle>
+                                <DropdownMenu>
+                                    <DropdownItem onClick={() => this.setState({compact: true})}>Compact</DropdownItem>
+                                    <DropdownItem onClick={() => this.setState({compact: false})}>Expanded</DropdownItem>
+                                </DropdownMenu>
+                            </Dropdown>
                         </Col>
                         <Col>
                             <AnnotationListReadOnly
-                                annotationOrder={this.props.annotationOrder} />
+                                annotationOrder={this.props.annotationOrder}
+                                compact={this.state.compact} />
                         </Col>
                     </Row>
                 </ListGroupItem>

--- a/src/js/ui/evidenceWith/listItemReadOnly.jsx
+++ b/src/js/ui/evidenceWith/listItemReadOnly.jsx
@@ -9,22 +9,32 @@ class EvidenceWithReadOnly extends React.Component {
     }
 
     render() {
-        return (
-            <ListGroupItem key={`evidence_with_${this.props.evidenceWithId}`}>
-                {this.props.evidenceWith.locusName}
-            </ListGroupItem>
-        );
+        if (this.props.isListGroupItem) {
+            return (
+                <ListGroupItem key={`evidence_with_${this.props.evidenceWithId}`}>
+                    {this.props.evidenceWith.locusName}
+                </ListGroupItem>
+            );
+        } else {
+            return (
+                <span key={`evidence_with_${this.props.evidenceWithId}`}>
+                    {this.props.evidenceWith.locusName}
+                </span>
+            );
+        }
     }
 }
 
 EvidenceWithReadOnly.propTypes = {
     evidenceWith: React.PropTypes.object,
     evidenceWithId: React.PropTypes.string,
+    isListGroupItem: React.PropTypes.bool,
 };
 
 EvidenceWithReadOnly.defaultProps = {
     evidenceWith: null,
     evidenceWithId: null,
+    isListGroupItem: true,
 };
 
 export default EvidenceWithReadOnly;

--- a/src/js/ui/submission/viewReadOnly.jsx
+++ b/src/js/ui/submission/viewReadOnly.jsx
@@ -6,11 +6,23 @@ import 'css/submissionView.scss';
 import PublicationFieldReadOnly from 'modules/connectedComponents/publication/fieldReadOnly';
 import AnnotationListReadOnly from 'ui/annotation/listReadOnly';
 import GeneListReadOnly from 'ui/gene/listReadOnly';
+import { Dropdown, DropdownToggle, DropdownMenu, DropdownItem } from 'reactstrap';
 
 class SubmissionReadOnly extends React.Component {
     constructor(props) {
         super(props);
 
+        this.state ={
+            dropdownOpen: false,
+            compact: true
+        };
+        this.toggleViewMode = this.toggleViewMode.bind(this);
+    }
+
+    toggleViewMode() {
+        this.setState({
+            dropdownOpen: !this.state.dropdownOpen
+        });
     }
 
     render() {
@@ -33,9 +45,20 @@ class SubmissionReadOnly extends React.Component {
                     <Row className="mt-3">
                         <Col sm="3">
                             <h5>Annotations</h5>
+                            <Dropdown isOpen={this.state.dropdownOpen} toggle={this.toggleViewMode}>
+                                <DropdownToggle caret color="success">
+                                    View Mode
+                                </DropdownToggle>
+                                <DropdownMenu style={{zIndex: 10000}}>
+                                    <DropdownItem onClick={() => this.setState({compact: true})}>Compact</DropdownItem>
+                                    <DropdownItem onClick={() => this.setState({compact: false})}>Expanded</DropdownItem>
+                                </DropdownMenu>
+                            </Dropdown>
                         </Col>
                         <Col>
-                            <AnnotationListReadOnly annotationOrder={this.props.annotationOrder} />
+                        <AnnotationListReadOnly
+                                annotationOrder={this.props.annotationOrder}
+                                compact={this.state.compact} />
                         </Col>
                     </Row>
                 </ListGroupItem>


### PR DESCRIPTION

Adds a compact UI that is on by default. The expanded view can be toggled to with the side dropdown.
 This fixes tair/toastdos-back#233.
![image](https://user-images.githubusercontent.com/1115017/38224343-944d39ac-36bd-11e8-88bf-218b2a1f5ae5.png)
