### PR TITLE
PHX-726: Fix locus identifier case mismatch.

### DIFF
--- a/src/app/shared/elements/evidence-with-locus/evidence-with-locus.component.ts
+++ b/src/app/shared/elements/evidence-with-locus/evidence-with-locus.component.ts
@@ -1,6 +1,6 @@
 import {Component, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild} from '@angular/core';
 import {FormControl, FormGroup} from '@angular/forms';
-import {debounceTime, distinctUntilChanged, tap} from 'rxjs/operators';
+import {debounceTime, distinctUntilChanged, map, tap} from 'rxjs/operators';
 import {Annotation, Gene, SubmissionService} from '../../services/submission.service';
 import {GeneService} from '../../services/gene.service';
 import {ValidationService} from '../../services/validation.service';
@@ -44,16 +44,19 @@ export class EvidenceWithLocusComponent implements OnInit, OnDestroy {
     this.locusField.valueChanges
       .pipe(
         debounceTime(400),
+        map((v: string) => (v || '').toUpperCase().trim()),
+        tap(normalized => {
+          const raw = (this.locusField.value || '').toString();
+          if (raw !== normalized) {
+            this.locusField.patchValue(normalized, {emitEvent: false});
+          }
+        }),
         distinctUntilChanged(),
-        tap(value => {
+        tap(() => {
           this.locusStatus = 'loading';
           this.toggleErrorPopover();
         })
       ).subscribe((value: string) => {
-      value = (value || '').toUpperCase().trim();
-      if (value !== this.locusField.value) {
-        this.locusField.patchValue(value, {emitEvent: false});
-      }
       this.geneService.checkLocus$(value)
         .subscribe((response: any) => {
             this.locusStatus = 'success';

--- a/src/app/shared/elements/evidence-with-locus/evidence-with-locus.component.ts
+++ b/src/app/shared/elements/evidence-with-locus/evidence-with-locus.component.ts
@@ -39,7 +39,7 @@ export class EvidenceWithLocusComponent implements OnInit, OnDestroy {
     {
         this.locusStatus = 'success';
     }
-    this.form.setValue({'locusField': this.locus});
+    this.form.setValue({'locusField': (this.locus || '').toUpperCase().trim()});
 
     this.locusField.valueChanges
       .pipe(
@@ -50,6 +50,10 @@ export class EvidenceWithLocusComponent implements OnInit, OnDestroy {
           this.toggleErrorPopover();
         })
       ).subscribe((value: string) => {
+      value = (value || '').toUpperCase().trim();
+      if (value !== this.locusField.value) {
+        this.locusField.patchValue(value, {emitEvent: false});
+      }
       this.geneService.checkLocus$(value)
         .subscribe((response: any) => {
             this.locusStatus = 'success';
@@ -78,7 +82,7 @@ export class EvidenceWithLocusComponent implements OnInit, OnDestroy {
   }
 
   validate() {
-    if (this.locusStatus=='error' || this.locusField.toString().length<2 || this.locusStatus=='empty')
+    if (this.locusStatus=='error' || (this.locusField.value || '').toString().length<2 || this.locusStatus=='empty')
     {
       this.errorMessage = "INVALID: A valid gene is required";
       this.locusStatus = 'error';


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: limited to client-side input normalization/validation in a single Angular component, with no backend or auth changes.
> 
> **Overview**
> Normalizes locus identifiers in `EvidenceWithLocusComponent` by uppercasing and trimming both the initial `@Input() locus` value and all subsequent user edits before verification.
> 
> Adds an RxJS normalization step (`map` + `patchValue` without re-emitting) so `checkLocus$` always receives a consistent value, and fixes validation to check `locusField.value` (not the control object) when enforcing minimum length.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4d8ede0065b357a3ff05a22aff06e41ca578a49. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->