### PR TITLE
PHX-726: Fix module loading.

### DIFF
--- a/src/app/shared/elements/annotation-types/annatomical/annatomical.component.ts
+++ b/src/app/shared/elements/annotation-types/annatomical/annatomical.component.ts
@@ -6,7 +6,7 @@ import {debounceTime, distinctUntilChanged, switchMap} from "rxjs/operators";
 import {MethodDropdownComponent} from "../../method-dropdown/method-dropdown.component";
 import {Annotation, Gene, SubmissionService} from "../../../services/submission.service";
 import {ValidationService} from '../../../services/validation.service';
-import {resetGeneControlsIfLocusNotInSubmission} from './annotation-gene-validation';
+import {resetGeneControlsIfLocusNotInSubmission} from '../annotation-gene-validation';
 
 @Component({
   selector: 'app-annatomical',

--- a/src/app/shared/elements/annotation-types/biological/biological.component.ts
+++ b/src/app/shared/elements/annotation-types/biological/biological.component.ts
@@ -6,7 +6,7 @@ import {debounceTime, distinctUntilChanged, switchMap} from "rxjs/operators";
 import {MethodDropdownComponent} from "../../method-dropdown/method-dropdown.component";
 import {Annotation, Gene, SubmissionService} from "../../../services/submission.service";
 import {ValidationService} from '../../../services/validation.service';
-import {resetGeneControlsIfLocusNotInSubmission} from './annotation-gene-validation';
+import {resetGeneControlsIfLocusNotInSubmission} from '../annotation-gene-validation';
 
 @Component({
   selector: 'app-biological',

--- a/src/app/shared/elements/annotation-types/comment/comment.component.ts
+++ b/src/app/shared/elements/annotation-types/comment/comment.component.ts
@@ -6,7 +6,7 @@ import {Observable} from "rxjs";
 import {debounceTime, distinctUntilChanged, switchMap} from "rxjs/operators";
 import {Annotation, Gene, SubmissionService} from "../../../services/submission.service";
 import {ValidationService} from '../../../services/validation.service';
-import {resetGeneControlsIfLocusNotInSubmission} from './annotation-gene-validation';
+import {resetGeneControlsIfLocusNotInSubmission} from '../annotation-gene-validation';
 
 @Component({
   selector: 'app-comment',

--- a/src/app/shared/elements/annotation-types/molecular/molecular.component.ts
+++ b/src/app/shared/elements/annotation-types/molecular/molecular.component.ts
@@ -5,7 +5,7 @@ import { Observable, of } from 'rxjs';
 import { debounceTime, map, distinctUntilChanged, switchMap } from 'rxjs/operators';
 import { Annotation, Gene, SubmissionService } from "../../../services/submission.service";
 import {ValidationService} from '../../../services/validation.service';
-import {resetGeneControlsIfLocusNotInSubmission} from './annotation-gene-validation';
+import {resetGeneControlsIfLocusNotInSubmission} from '../annotation-gene-validation';
 
 @Component({
   selector: 'app-molecular',

--- a/src/app/shared/elements/annotation-types/protein-interaction/protein-interaction.component.ts
+++ b/src/app/shared/elements/annotation-types/protein-interaction/protein-interaction.component.ts
@@ -6,7 +6,7 @@ import {Observable} from "rxjs";
 import {debounceTime, distinctUntilChanged, switchMap} from "rxjs/operators";
 import {Annotation, Gene, SubmissionService} from "../../../services/submission.service";
 import {ValidationService} from '../../../services/validation.service';
-import {resetGeneControlsIfLocusNotInSubmission} from './annotation-gene-validation';
+import {resetGeneControlsIfLocusNotInSubmission} from '../annotation-gene-validation';
 
 @Component({
   selector: 'app-protein-interaction',

--- a/src/app/shared/elements/annotation-types/subcellular/subcellular.component.ts
+++ b/src/app/shared/elements/annotation-types/subcellular/subcellular.component.ts
@@ -6,7 +6,7 @@ import {debounceTime, distinctUntilChanged, switchMap} from "rxjs/operators";
 import {MethodDropdownComponent} from "../../method-dropdown/method-dropdown.component";
 import {Annotation, Gene, SubmissionService} from "../../../services/submission.service";
 import {ValidationService} from '../../../services/validation.service';
-import {resetGeneControlsIfLocusNotInSubmission} from './annotation-gene-validation';
+import {resetGeneControlsIfLocusNotInSubmission} from '../annotation-gene-validation';
 
 @Component({
   selector: 'app-subcellular',

--- a/src/app/shared/elements/annotation-types/temporal/temporal.component.ts
+++ b/src/app/shared/elements/annotation-types/temporal/temporal.component.ts
@@ -6,7 +6,7 @@ import {debounceTime, distinctUntilChanged, switchMap} from "rxjs/operators";
 import {MethodDropdownComponent} from "../../method-dropdown/method-dropdown.component";
 import {Annotation, Gene, SubmissionService} from "../../../services/submission.service";
 import {ValidationService} from '../../../services/validation.service';
-import {resetGeneControlsIfLocusNotInSubmission} from './annotation-gene-validation';
+import {resetGeneControlsIfLocusNotInSubmission} from '../annotation-gene-validation';
 
 @Component({
   selector: 'app-temporal',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this is a path-only change to fix module resolution for multiple annotation components, with no runtime logic changes beyond which module file is loaded.
> 
> **Overview**
> Fixes module loading for annotation forms by updating multiple annotation components (`annatomical`, `biological`, `comment`, `molecular`, `protein-interaction`, `subcellular`, `temporal`) to import `resetGeneControlsIfLocusNotInSubmission` from the centralized `annotation-gene-validation` module (`../annotation-gene-validation`) instead of a sibling file path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 740a250cfb7b80c4ae7ef656dbeffcd81f68c43e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->